### PR TITLE
Add two missing cases in delMin BinomialHeaps.cpp

### DIFF
--- a/data-structures/binomial-heaps/BinomialHeaps.cpp
+++ b/data-structures/binomial-heaps/BinomialHeaps.cpp
@@ -376,6 +376,10 @@ public:
 			prevMin->sibling = minPtr->sibling;
 		} else if (prevMin != nullptr && minPtr->sibling == nullptr) {
 			prevMin->sibling = nullptr;
+		}else if(prevMin == nullptr and minPtr->sibling != nullptr) {
+		        head = minPtr->sibling;
+		}else if(prevMin == nullptr and minPtr->sibling == nullptr) {
+		        head = nullptr;
 		}
 
 		// remove parent reference from all its child


### PR DESCRIPTION
You missed two cases in deleteMin.
when the minPtr has no sibling before or after i.e. there is only a single tree in the heap
and
when minPtr is the head of the heap and it has at least one sibling(i.e. there are multiple trees)