### PR TITLE
Added missed two cases in delete-Min

### DIFF
--- a/data-structures/binomial-heaps/BinomialHeaps.cpp
+++ b/data-structures/binomial-heaps/BinomialHeaps.cpp
@@ -377,6 +377,12 @@ public:
 		} else if (prevMin != nullptr && minPtr->sibling == nullptr) {
 			prevMin->sibling = nullptr;
 		}
+		else if (prevMin == nullptr && minPtr->sibling == nullptr) {
+			setHead(nullptr);
+		}
+		else if (prevMin == nullptr && minPtr->sibling != nullptr) {
+			setHead(minPtr->sibling);
+		}
 
 		// remove parent reference from all its child
 		NodePtr childPtr = minPtr->child;


### PR DESCRIPTION
You have missed two cases where delete min can extract the head node whose previous Node is null. Handled those two case.