### PR TITLE
Update RedBlackTree.cpp

### DIFF
--- a/data-structures/red-black-trees/RedBlackTree.cpp
+++ b/data-structures/red-black-trees/RedBlackTree.cpp
@@ -112,7 +112,7 @@ private:
 					s = x->parent->left;
 				}
 
-				if (s->right->color == 0 && s->right->color == 0) {
+				if (s->right->color == 0 && s->left->color == 0) {
 					// case 3.2
 					s->color = 1;
 					x = x->parent;


### PR DESCRIPTION
In line 115, the reverse version of fix-delete, it was checking the right and right children of the sibling but it still needs to check both the right and the left children and make sure they both are BLACK.